### PR TITLE
improved uigetfile with 'jt_times*.*'

### DIFF
--- a/drgBehaviorbyBlock.m
+++ b/drgBehaviorbyBlock.m
@@ -1,5 +1,5 @@
 function drgBehaviorbyBlock(handles)
-
+disp('justin_test');
 
 [perCorr, encoding_trials, retrieval_trials, encoding_this_evTypeNo,retrieval_this_evTypeNo]=drgFindEncRetr(handles);
 

--- a/drgMaster.m
+++ b/drgMaster.m
@@ -186,7 +186,7 @@ function openDrg_Callback(hObject, eventdata, handles)
 % eventdata  reserved - to be defined in a future version of MATLAB
 % handles    structure with handles and user data (see GUIDATA)
 
-[FileName,PathName] = uigetfile('*.*','Select . drg file to open');
+[FileName,PathName] = uigetfile('jt_times*.*','Select . drg file to open');
 handles.fullName=[PathName,FileName];
 handles.FileName=FileName;
 handles.PathName=PathName;


### PR DESCRIPTION
Now, instead of being shown every file type under the sun, when uigetfile executes, you will only be shown jt_times files by default. You can always change the selection to "show all file types" as a backup in the explorer window.